### PR TITLE
Add missing dependency on satysfi-base 

### DIFF
--- a/satysfi-easytable.opam
+++ b/satysfi-easytable.opam
@@ -13,15 +13,15 @@ dev-repo: "git+https://github.com/monaqa/satysfi-easytable.git"
 
 depends: [
   "satysfi" {>= "0.0.5" & < "0.0.7"}
-  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-base" {>= "1.4.0" & < "2.0.0"}
 ]
 build: [ ]
 install: [
   ["satyrographos" "opam" "install"
-   "-name" "easytable"
-   "-prefix" "%{prefix}%"
-   "-script" "%{build}%/Satyristes"]
+   "--name" "easytable"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
 ]
 

--- a/satysfi-easytable.opam
+++ b/satysfi-easytable.opam
@@ -15,6 +15,7 @@ depends: [
   "satysfi" {>= "0.0.5" & < "0.0.7"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
+  "satysfi-base" {>= "1.4.0" & < "2.0.0"}
 ]
 build: [ ]
 install: [


### PR DESCRIPTION
This PR adds a missing dependency on satysfi-base. This is an upstream patch of https://github.com/na4zagin3/satyrographos-repo/pull/307.


This also have the OPAM require more recent version of Satyristes because satysfi-easytable requires SATySFi 0.0.5 or later.